### PR TITLE
docs(github): change contributing link to use local repository file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to consume community or core components:
 
 ## Contributing
 
-To learn how to make contributions to TDS Community, See the [contributing guide](https://tds.telus.com/contributing/contributing.html).
+To learn how to make contributions to TDS Community, See the [contributing guide](./.github/CONTRIBUTING.md).
 
 ## Contributors
 


### PR DESCRIPTION
I noticed that this was linking to production docs, which was unintentional.